### PR TITLE
awk -e is not supported in mawk or nawk.

### DIFF
--- a/install-v8-libs.sh
+++ b/install-v8-libs.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 VersionHeader=ThirdParty/v8/include/v8-version.h
-Major=$(cat $VersionHeader | grep MAJOR | awk -e '{ print $3 }')
-Minor=$(cat $VersionHeader | grep MINOR | awk -e '{ print $3 }')
-Build=$(cat $VersionHeader | grep BUILD_NUMBER | awk -e '{ print $3 }')
+Major=$(cat $VersionHeader | grep MAJOR | awk '{ print int($3) }')
+Minor=$(cat $VersionHeader | grep MINOR | awk '{ print int($3) }')
+Build=$(cat $VersionHeader | grep BUILD_NUMBER | awk '{ print int($3) }')
 Version=$Major.$Minor.$Build
 Tag=V8-$Version
 ZipFile=v8-$Version-libs.zip


### PR DESCRIPTION
nawk is the default for awk on Mac and mawk is the default on Ubuntu. Rather than rely on gawk specific syntax, this shorter version works just as well, and in all implementations.